### PR TITLE
Tweak ZAP references

### DIFF
--- a/challenges/single/HTMLFieldRestrictions/index.php
+++ b/challenges/single/HTMLFieldRestrictions/index.php
@@ -56,7 +56,7 @@ class HTMLFieldRestrictions extends BaseLesson
     public function start()
     {
         $this->hints = array(
-            'Use OWASP ZAP',
+            'Use ZAP',
             'Modify the values of all the parameters in request'
         );
 

--- a/challenges/single/HTTPBasics/content.html
+++ b/challenges/single/HTTPBasics/content.html
@@ -6,7 +6,7 @@
 <p>
     The user should become familiar with the features of WebGoat by manipulating the above buttons to
     view hints, show the HTTP request parameters, the HTTP request cookies, and the PHP source code. You may also
-    try using OWASP ZAP for the first time
+    try using ZAP for the first time
 </p>
 <br>
 <form class="form-inline" method="POST">

--- a/challenges/single/HTTPBasics/index.php
+++ b/challenges/single/HTTPBasics/index.php
@@ -57,7 +57,7 @@ class HTTPBasics extends BaseLesson
             $this->hints,
             "Type in your name and press 'Submit'",
             "Turn on Show Parameters or other features",
-            "Try to intercept the request with OWASP ZAP",
+            "Try to intercept the request with ZAP",
             "Press the Show Lesson Plan button to view a lesson summary",
             "Press the Show Solution button to view a lesson solution"
         );

--- a/challenges/single/HTTPBasics/static/plan.html
+++ b/challenges/single/HTTPBasics/static/plan.html
@@ -19,6 +19,6 @@
     The server will accept the request, and display it back to the user,
     illustrating the basics of handling an HTTP request.</p>
 
-<p>The user should become familiar with the features of OWASP ZAP by manipulating the above buttons to view hints,
+<p>The user should become familiar with the features of ZAP by manipulating the above buttons to view hints,
     show the HTTP request parameters, the HTTP request cookies, and the PHP source code.
-    You may also try using OWASP ZAP for the first time. </p>
+    You may also try using ZAP for the first time. </p>

--- a/challenges/single/HTTPBasics/static/solution.html
+++ b/challenges/single/HTTPBasics/static/solution.html
@@ -1,7 +1,7 @@
 <h3>Solution</h3>
 
 <p>
-Add a Proxy on localhost in the settings of your browser. Then you can start OWASP ZAP/WebScarab. We have to select "intercept request" in the tab "Intercept".</p>
+Add a Proxy on localhost in the settings of your browser. Then you can start ZAP/WebScarab. We have to select "intercept request" in the tab "Intercept".</p>
 
 <img src="static/webscarab1.png" alt="Web Scarab" width="500px"/>
 

--- a/challenges/single/UsefulTools/content.html
+++ b/challenges/single/UsefulTools/content.html
@@ -1,6 +1,6 @@
 <p>Below is a list of tools which might be useful in solving lessons. You will need a proxy like ZAP to solve most of the lessons. </p>
 <br>
-<h4>OWASP ZAP</h4>
+<h4>ZAP</h4>
 <p>The Zed Attack Proxy (ZAP) is an easy to use integrated penetration testing tool for finding vulnerabilities in web applications. ZAP provides automated scanners as well as a set of tools that allow you to find security vulnerabilities manually.</p><br>
 
 <img src="static/zap1.png" alt="Zed Attack Proxy" class="img-responsive"><br>


### PR DESCRIPTION
ZAP left OWASP over a year ago, this just adjusts naming.